### PR TITLE
Bugfix & Improvements on mc-dl and mc-versions methods

### DIFF
--- a/app/plugins/MC.php
+++ b/app/plugins/MC.php
@@ -32,10 +32,10 @@ class Wiz_Plugin_MC extends Wiz_Plugin_Abstract {
    * @author Nicholas Vahalik <nick@classyllama.com>
    **/
   public function dlAction($options) {
+    $options = $this->_getFixedOptions($options);
     if (count($options) == 0) {
       echo 'Please supply a Magento Connect 1.0 or 2.0 key.';
     }
-
     $key = $options[0];
     $selectedVersion = 'latest';
     $selectedBranch = 'stable';
@@ -65,8 +65,9 @@ class Wiz_Plugin_MC extends Wiz_Plugin_Abstract {
    * @author Nicholas Vahalik <nick@classyllama.com>
    */
   public function versionsAction($options) {
+    $options = $this->_getFixedOptions($options);
     if (count($options) == 0) {
-      echo 'Please supply a Magento Connect 1.0 or 2.0 key.';
+      throw new Exception('Please supply a Magento Connect 1.0 or 2.0 key.');
     }
 
     $key = $options[0];
@@ -154,5 +155,19 @@ class Wiz_Plugin_MC extends Wiz_Plugin_Abstract {
           }
       }
       return 0;
+  }
+
+  private function _getFixedOptions($options){
+      if(
+        is_array($options) && 
+        isset($options[0]) && 
+        strpos($options[0], 'http') !== FALSE && 
+        isset($options[1]) &&
+        strpos($options[1], '//') !== FALSE
+        ){
+        return array(0=>$options[0] . ':' . $options[1]);
+      }else{
+        return $options;
+      }
   }
 }


### PR DESCRIPTION
When using error_reporting E_ALL we got some notices when passing a bad url to mc-\* methods like:

> martins@martins-ux:/var/www/mageclean$ wiz mc-versions 
> Please supply a Magento Connect 1.0 or 2.0 key.PHP Notice:  Undefined offset: 0 in /var/www/modulos/Wiz/app/plugins/MC.php on line 72
> PHP Stack trace:
> PHP   1. {main}() /var/www/modulos/Wiz/wiz.php:0
> PHP   2. Wiz->run() /var/www/modulos/Wiz/wiz.php:24
> PHP   3. Wiz_Plugin_MC->versionsAction() /var/www/modulos/Wiz/app/Wiz.php:379
> 
> Notice: Undefined offset: 0 in /var/www/modulos/Wiz/app/plugins/MC.php on line 72
> 
> Call Stack:
>    0.0002     226080   1. {main}() /var/www/modulos/Wiz/wiz.php:0
>    0.0081    1115088   2. Wiz->run() /var/www/modulos/Wiz/wiz.php:24
>    0.0081    1115696   3. Wiz_Plugin_MC->versionsAction() /var/www/modulos/Wiz/app/Wiz.php:379
> I fixed it with adding a throw exception instead of a simple echo.

And...
When i tried to use mc-dl or mc-versions on Ubuntu, the $options array turns into 2 items array:

> martins@martins-ux:/var/www/strar$ wiz mc-dl http://connect20.magentocommerce.com/community/Inchoo_FeaturedProducts
> array(2) {
>  [0] =>
>  string(4) "http"
>  [1] =>
>  string(65) "//connect20.magentocommerce.com/community/Inchoo_FeaturedProducts"
> }

I fixed it by adding _getFixedOptions() private method. It's far from perfection, but now it works without saying _Only support MC 2.0 keys at this time.  Sorry!_
