### PR TITLE
Use getenv() instead of $_ENV

### DIFF
--- a/app/Wiz.php
+++ b/app/Wiz.php
@@ -97,7 +97,7 @@ class Wiz {
     static function getMagentoRoot() {
         static $magentoRoot = FALSE;
         if ($magentoRoot === FALSE) {
-            $wizMagentoRoot = array_key_exists('WIZ_MAGE_ROOT', $_ENV) ? $_ENV['WIZ_MAGE_ROOT'] : getcwd();
+            $wizMagentoRoot = getenv('WIZ_MAGE_ROOT') ? getenv('WIZ_MAGE_ROOT') : getcwd();
 
             // Run through all of the options until either we find something, or we've run out of places to look.
             do {


### PR DESCRIPTION
From issue https://github.com/classyllama/Wiz/issues/22

getenv() doesn't require E activated in variables_order, though will work from scratch on every server without it activated
